### PR TITLE
add Dockerfile and update README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM rust:1.67 as builder
+
+WORKDIR /usr/src/nonce_guess
+COPY . .
+
+RUN rustup target add wasm32-unknown-unknown && cargo install trunk
+RUN trunk build --release ng_web/index.html && cargo build --bin ng_server --release
+RUN cargo install --path ./ng_server
+
+FROM debian:11
+
+WORKDIR /root
+
+RUN apt update && apt upgrade -y
+RUN apt install -y git build-essential openssl librust-openssl-dev software-properties-common
+
+COPY --from=builder /usr/local/cargo/bin/ng_server .
+EXPOSE 8081
+
+CMD ["RUST_LOG=debug ./ng_server"]

--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ By default the data is stored in SQLite memory database.
 To run the resulting self contained binary use `RUST_LOG=debug target/release/ng_server`.
 
 In test or release mode the web client can be found at: http://127.0.0.1:8081/
+
+### Build Docker Container
+
+1. `docker build -t nonce_guess .`
+2. `docker run --rm -it -p 8081:8081 --name nonce_guess_app nonce_guess`
+3. Visit http://127.0.0.1:8081/ in a browser


### PR DESCRIPTION
- Adding Dockerfile and updates to README
- Build using `docker build -t nonce_guess .`
- Run using `docker run --rm -it -p 8081:8081 --name nonce_guess_app nonce_guess`
- Upon running, it will fail to find the command `./ng_server`; however, if you run `docker run --rm -it -p 8081:8081 --name nonce_guess_app /bin/bash` and do `ls -l` you will see the binary present
- Once inside container, if you run `RUST_LOG=debug ./ng_server` you will see the server run; however, if you go to `http://127.0.0.1:8081/` in a browser, you get no response from the server