### PR TITLE
fix breaking change: remove the UNIQUE constraint

### DIFF
--- a/ng_server/migrations/20221210_create_tables.sql
+++ b/ng_server/migrations/20221210_create_tables.sql
@@ -1,2 +1,2 @@
 CREATE TABLE target (block INTEGER, nonce INTEGER WITHOUT ROWID, UNIQUE(block));
-CREATE TABLE guess (player_name TEXT NOT NULL, block INTEGER REFERENCES target (block), nonce INTEGER NOT NULL, UNIQUE(player_name, block));
+CREATE TABLE guess (player_name TEXT NOT NULL, block INTEGER REFERENCES target (block), nonce INTEGER NOT NULL);

--- a/ng_server/migrations/20221210_create_tables.sql
+++ b/ng_server/migrations/20221210_create_tables.sql
@@ -1,2 +1,3 @@
 CREATE TABLE target (block INTEGER, nonce INTEGER WITHOUT ROWID, UNIQUE(block));
-CREATE TABLE guess (player_name TEXT NOT NULL, block INTEGER REFERENCES target (block), nonce INTEGER NOT NULL);
+CREATE TABLE guess (player_name TEXT NOT NULL, block INTEGER REFERENCES target (block), nonce INTEGER NOT NULL, UNIQUE(player_name, block));
+CREATE UNIQUE INDEX idx_guess_null_block ON guess(player_name) WHERE block IS NULL;


### PR DESCRIPTION
- Removing `UNIQUE` constraint from  `guess.player_name` and ` guess.block`
- `UNIQUE` constraint causes fatal error on update press once block has been mined
- nonces cannot be calculated