### PR TITLE
Feature/check dupe guess

### DIFF
--- a/ng_model/src/lib.rs
+++ b/ng_model/src/lib.rs
@@ -39,7 +39,7 @@ pub fn sort_guesses_by_nonce(guesses: &mut [Guess]) {
     guesses.sort_by_key(|g| g.nonce)
 }
 
-pub fn check_for_duplicate_guess(
+pub fn no_duplicate_guess(
     fetched_guesses: &mut [Guess],
     new_guess: &Guess,
 ) -> Result<bool, Guess> {

--- a/ng_model/src/lib.rs
+++ b/ng_model/src/lib.rs
@@ -38,3 +38,17 @@ pub fn sort_guesses_by_target_diff(guesses: &mut [Guess], target_nonce: u32) {
 pub fn sort_guesses_by_nonce(guesses: &mut [Guess]) {
     guesses.sort_by_key(|g| g.nonce)
 }
+
+pub fn check_for_duplicate_guess(
+    fetched_guesses: &mut [Guess],
+    new_guess: &Guess,
+) -> Result<bool, Guess> {
+    for fetched_guess in fetched_guesses.iter() {
+        if (fetched_guess.block.is_none() || fetched_guess.block == new_guess.block)
+            && fetched_guess.name == new_guess.name
+        {
+            return Err(fetched_guess.clone());
+        }
+    }
+    return Ok(true);
+}

--- a/ng_web/src/app.rs
+++ b/ng_web/src/app.rs
@@ -2,7 +2,7 @@ use crate::block_entry::BlockEntry;
 use crate::guess_entry::GuessEntry;
 use gloo_net::http::Request;
 use log::{debug, info};
-use ng_model::{check_for_duplicate_guess, sort_guesses_by_target_diff, Guess, Target};
+use ng_model::{no_duplicate_guess, sort_guesses_by_target_diff, Guess, Target};
 use std::rc::Rc;
 use std::str::FromStr;
 use thousands::Separable;
@@ -29,7 +29,6 @@ enum Route {
 
 #[function_component(Secure)]
 fn secure() -> Html {
-
     let state = use_reducer(|| AppState {
         target: None,
         guesses: None,
@@ -59,7 +58,7 @@ fn secure() -> Html {
             }
         })
     };
-    
+
     html! {
         <div class="section">
             <div class="container">
@@ -248,7 +247,7 @@ fn home() -> Html {
                             .await
                             .unwrap();
                     let is_dupe: Result<_, _> =
-                        check_for_duplicate_guess(fetched_guesses.as_mut_slice(), &guess);
+                        no_duplicate_guess(fetched_guesses.as_mut_slice(), &guess);
                     match is_dupe {
                         Ok(s) => info!("Guess does not exist: {:?}", s),
                         Err(e) => {

--- a/ng_web/src/app.rs
+++ b/ng_web/src/app.rs
@@ -246,9 +246,9 @@ fn home() -> Html {
                             .json()
                             .await
                             .unwrap();
-                    let is_dupe: Result<_, _> =
+                    let is_not_dupe: Result<_, _> =
                         no_duplicate_guess(fetched_guesses.as_mut_slice(), &guess);
-                    match is_dupe {
+                    match is_not_dupe {
                         Ok(s) => info!("Guess does not exist: {:?}", s),
                         Err(e) => {
                             let err_msg = format!("You cannot submit multiple guesses {:?}", e);


### PR DESCRIPTION
**Done**
- adds function `no_duplicate_guess` to lib.rs to check the `fetched_guesses` against the `new_guess` submitted
- if the `fetched_guess` from DB has a null block or is equal to the `new_guess.block` and `fetched_guess.name` is equal to `new_guess.name` return `Err(fetched_guess.clone())`
- Else return `Ok(true)` that no dupes exist
- move fetching the target, block_path and guesses in front of posting new guess to API
- after fetching gueses, check for dupes; if no dupes, add new guess to DB, else fail with basic debug

**To Do**
- handle the dupe exists error with a frontend alert to the user
- need help on this task, unsure how to achieve this behavior