### PR TITLE
Add unique constraint for guessed nonce

### DIFF
--- a/ng_server/migrations/20221210_create_tables.sql
+++ b/ng_server/migrations/20221210_create_tables.sql
@@ -1,3 +1,4 @@
 CREATE TABLE target (block INTEGER, nonce INTEGER WITHOUT ROWID, UNIQUE(block));
-CREATE TABLE guess (player_name TEXT NOT NULL, block INTEGER REFERENCES target (block), nonce INTEGER NOT NULL, UNIQUE(player_name, block));
-CREATE UNIQUE INDEX idx_guess_null_block ON guess(player_name) WHERE block IS NULL;
+CREATE TABLE guess (player_name TEXT NOT NULL, block INTEGER REFERENCES target (block), nonce INTEGER NOT NULL, UNIQUE(player_name, block), UNIQUE(nonce, block));
+CREATE UNIQUE INDEX idx_guess_player_name_null_block ON guess(player_name) WHERE block IS NULL;
+CREATE UNIQUE INDEX idx_guess_nonce_null_block ON guess(nonce) WHERE block IS NULL;


### PR DESCRIPTION
This PR doesn't handle displaying the errors, that will take a bit more work. But this will prevent guesses with the same nonce for the same target block.